### PR TITLE
Add release helper script

### DIFF
--- a/pr_summaries.py
+++ b/pr_summaries.py
@@ -66,6 +66,8 @@ def main():
     parser.add_argument("--token", help="Supply a token for GitHub read access (optional)", default=None)
     args = parser.parse_args()
 
+    if token is None:
+        print("Warning: You have not passed a token so you may run into GitHub rate limiting.")
     api = GhApi(repo="osbuild", owner='osbuild', token=args.token)
 
     milestone = get_milestone(api, args.version)

--- a/pr_summaries.py
+++ b/pr_summaries.py
@@ -5,19 +5,22 @@
 #
 
 # Requires: pip install ghapi (https://ghapi.fast.ai/)
-# Optional: A token to read from GitHub (there is a rate limit for anonymous API calls)
+# Optional: A token to read from GitHub (there is a rate limit for
+# anonymous API calls)
 
 
 from ghapi.all import GhApi
 import argparse
 import os
 
+
 def get_milestone(api, version):
     milestones = api.issues.list_milestones()
     for milestone in milestones:
         if version in milestone.title:
-            print ("%s (id %s)" % (milestone.title, milestone.number))
+            print("%s (id %s)" % (milestone.title, milestone.number))
             return milestone.number
+
 
 def get_pullrequest_infos(api, milestone, f):
     prs = api.pulls.list(state="closed")
@@ -36,10 +39,17 @@ def get_pullrequest_infos(api, milestone, f):
 
     return pr_count
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--version", help="Set the `version` variable", default="31")
-    parser.add_argument("--token", help="Supply a token for GitHub read access (optional)", default=None)
+    parser.add_argument(
+        "--version",
+        help="Set the `version` variable",
+        default="31")
+    parser.add_argument(
+        "--token",
+        help="Supply a token for GitHub read access (optional)",
+        default=None)
     args = parser.parse_args()
 
     repo = os.path.basename(os.getcwd())
@@ -55,7 +65,8 @@ def main():
         f = open(filename, "a")
         pr_count = get_pullrequest_infos(api, milestone, f)
         f.close()
-        print ("\nWritten %s PR summaries to %s" % (pr_count, filename))
+        print("\nWritten %s PR summaries to %s" % (pr_count, filename))
+
 
 if __name__ == "__main__":
     main()

--- a/pr_summaries.py
+++ b/pr_summaries.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+#
+# Write title and body of GitHub pull requests for a certain milestone to a markdown file
+#
+
+# Requires: pip install ghapi (https://ghapi.fast.ai/)
+# Optional: A token to read from GitHub (there is a rate limit for anonymous API calls)
+
+
+from ghapi.all import GhApi
+import argparse
+import os
+
+def get_milestone(api, version):
+    milestones = api.issues.list_milestones()
+    for milestone in milestones:
+        if version in milestone.title:
+            print ("%s (id %s)" % (milestone.title, milestone.number))
+            return milestone.number
+
+def get_pullrequest_infos(api, milestone, f):
+    prs = api.pulls.list(state="closed")
+    i = 0
+    pr_count = 0
+
+    while i <= (len(prs)):
+        i += 1
+        prs = api.pulls.list(state="closed", page=i)
+
+        for pr in prs:
+            if pr.milestone is not None and pr.milestone.number == milestone:
+                pr_count += 1
+                print("%s" % pr.url)
+                f.write("  * %s: %s\n\n" % (pr.title, pr.body))
+
+    return pr_count
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", help="Set the `version` variable", default="31")
+    parser.add_argument("--token", help="Supply a token for GitHub read access (optional)", default=None)
+    args = parser.parse_args()
+
+    repo = os.path.basename(os.getcwd())
+
+    api = GhApi(repo=repo, owner='osbuild', token=args.token)
+
+    milestone = get_milestone(api, args.version)
+
+    filename = ("NEWS-%s.md" % args.version)
+    if (os.path.isfile(filename)):
+        print("Error: The file %s already exists." % filename)
+    else:
+        f = open(filename, "a")
+        pr_count = get_pullrequest_infos(api, milestone, f)
+        f.close()
+        print ("\nWritten %s PR summaries to %s" % (pr_count, filename))
+
+if __name__ == "__main__":
+    main()

--- a/release.py
+++ b/release.py
@@ -105,11 +105,11 @@ def guess_remote(repo):
 
 def update_news_osbuild(args):
     """Update the NEWS file for osbuild"""
-    # TODO: Need to decide how to handle the pr_summaries.py file (make it available as .egg?)
+    # TODO: Need to decide how to handle the update_news.py file (make it available as .egg?)
     # so it can be properly invoked
-    # TODO: Check the return code of pr_summaries.py to see if things actually worked as planned
-    step(f"Update NEWS.md with pull request summaries for milestone {args.version}", [
-         '../maintainer-tools/pr_summaries.py', '--version', f'{args.version}', '--token', f'{args.token}'])
+    # TODO: Check the return code of update_news.py to see if things actually worked as planned
+    step(f"Update NEWS.md with pull request summaries for milestone {args.version}",
+         ['../maintainer-tools/update_news.py', '--version', f'{args.version}', '--token', f'{args.token}', '--component', 'osbuild'])
 
 
 def update_news_composer(args):
@@ -117,7 +117,8 @@ def update_news_composer(args):
     step("Create a docs directory for this release and move all news files to it",
          ['mkdir', f'docs/news/{args.version}', '&&', 'mv', 'docs/news/unreleased/*', f'docs/news/{args.version}'])
     msg_info(f"Content of docs/news/{args.version}:\n{run_command(['ls',f'docs/news/{args.version}'])}")
-    step("Generate template for new release", ['make', 'release'])
+    step(f"Update NEWS.md with information from the markdown files in 'docs/news/{args.version}'",
+         ['../maintainer-tools/update_news.py', '--version', f'{args.version}', '--token', f'{args.token}', '--component', 'osbuild-composer'])
 
 
 def bump_version(version, filename):

--- a/release.py
+++ b/release.py
@@ -170,7 +170,7 @@ def release_playbook(args, repo, current_branch):
     elif repo == "osbuild-composer":
         update_news_composer(args)
 
-    step(f"Bump the version in the {repo}.spec", None)
+    step(f"Bump the version where necessary ({repo}.spec, potentially setup.py)", None)
     bump_version(args.version, f"{repo}.spec")
     if repo == "osbuild":
         bump_version(args.version, "setup.py")

--- a/release.py
+++ b/release.py
@@ -199,7 +199,7 @@ def main():
     remote = guess_remote(repo)
     username = getpass.getuser()
     # FIXME: Currently only works with GUI editors (e.g. not with vim)
-    editor = run_command(['git', 'config', '--default', '"${EDITOR:-vi}"', '--global', 'core.editor'])
+    editor = run_command(['git', 'config', '--default', '"${EDITOR:-gedit}"', '--global', 'core.editor'])
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", help=f"Set the version for the release (Default: {version})", default=version)

--- a/release.py
+++ b/release.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+
+#
+# Step interactively through the release process for osbuild
+#
+
+import argparse
+import subprocess, sys
+import os
+
+
+# Check if we are in a git repo, on the right branch and up-to-date
+def sanity_checks():
+    is_git = run_command(['git', 'rev-parse', '--is-inside-work-tree'])
+    if  is_git != "true":
+        print("Error: This is not a git repository.")
+        sys.exit(1)
+
+    current_branch = run_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+    if current_branch != "main":
+        print(f"Error: You are not on the 'main' branch but on branch '{current_branch}'.")
+        sys.exit(1)
+    else:
+        print(f"Updating '{current_branch}' to avoid conflicts...")
+
+    is_clean = run_command(['git', 'status', '--untracked-files=no', '--porcelain'])
+    if is_clean != "":
+        status = run_command(['git', 'status', '--untracked-files=no', '-s'])
+        print(f"The working directory is not clean.\n"
+               "You have the following unstaged or uncommitted changes:\n"
+               "{status}")
+    else:
+        run_command(['git', 'pull'])
+
+# Run a shellcommand and return stdout
+def run_command(argv):
+    result = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8').stdout
+    return result.strip()
+
+# Ask the user for confirmation on whether to continue
+def step(action, args):
+    # TODO: Consider adding a third state (skip?) so the playbook can be easily restarted
+    feedback = input(f"{action} [y/N] ")
+    if feedback == "y":
+        run_command(args)
+    else:
+        print("Release playbook canceled.")
+        sys.exit(0)
+
+# Bump the version of the latest git tag by 1
+def autoincrement_version():
+    latest_tag = run_command(['git', 'describe', '--abbrev=0'])
+    version = int(latest_tag.replace("v","")) + 1
+    return version
+
+# Guess the git remote to push the release changes to
+def guess_remote(repo):
+    origin = f"github.com/osbuild/{repo}.git"
+    remotes = run_command(['git','remote']).split("\n")
+    if len(remotes) > 2:
+        print(f"You have more than two 'git remotes' specified, so guessing the correct one will most likely fail.\n"
+               "Please use the --remote argument to set the correct one.\n"
+               "{remotes}")
+
+    for remote in remotes:
+        remote_url = run_command(['git','remote','get-url',f'{remote}'])
+        if remote_url.__contains__(origin) == False:
+            return remote
+
+# Execute all steps of the release playbook
+def release_playbook(version, remote, repo):
+    step(f"Check out a new branch for the release {version}", ['git', 'checkout', '-b', f'release-{version}'])
+    step("Generate template for new release", ['make', 'release'])
+    step(f"Bump the version to {version}", ['make', 'bump-version'])
+    step(f"Please make sure the version was bumped correctly to {version}", ['git', 'diff'])
+    # TODO: Call the pr_summaries.py script for osbuild or assemble the news from docs/news/unreleased for composer
+    step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
+          ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py', '-s', f'-m {version}', f'-m "Release osbuild {version}"'])
+    step(f"Push all release changes to the remote '{remote}'",
+          ['git', 'push', '--set-upstream', f'{remote}', f'release-{version}'])
+    # TODO: Create a PR on GitHub automatically (since we know all the necessary infos) and paste a link to it in stdout
+    print("Please use github to submit a pull-request against the main repository!")
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", help="Set the `version` for the release")
+    parser.add_argument("--remote", help="Set the `remote` on github to push the release changes to")
+    args = parser.parse_args()
+
+    # Do some initial sanity checking of the repository and its state
+    sanity_checks()
+
+    # Determine the version for the release
+    if (args.version is None):
+        version = autoincrement_version()
+    else:
+        version = args.version
+    
+    # Determine the remote to push the release to
+    repo = os.path.basename(os.getcwd())
+    if (args.remote is None):
+        remote = guess_remote(repo)
+    else:
+        remote = args.remote
+
+    # Run the release playbook
+    release_playbook(version, remote, repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/release.py
+++ b/release.py
@@ -165,7 +165,7 @@ def release_playbook(args, repo, current_branch):
     elif repo == "osbuild-composer":
         update_news_composer(args)
 
-    step(f"Make the notes in NEWS.md release ready using {args.editor}", [f'{args.editor}', 'NEWS.md'])
+    step(f"Make the notes in NEWS.md release ready using {args.editor}", [{args.editor}, 'NEWS.md'])
 
     step(f"Bump the version where necessary ({repo}.spec, potentially setup.py)", None)
     bump_version(args.version, f"{repo}.spec")

--- a/release.py
+++ b/release.py
@@ -153,11 +153,10 @@ def create_pullrequest(args, repo):
                }
 
     r = requests.post(url, json=payload, auth=(args.user, args.token))
-    # FIXME: Check the return code (201 for success) properly
-    try:
+    if r.status_code == 201:
         msg_ok(f"Pull request successfully created: {r.json()['url']}")
-    except:
-        msg_error(f"Failed to create pull request. {r.json()}")
+    else:
+        msg_error(f"Failed to create pull request: {r.status_code}")
 
 
 def release_playbook(args, repo, current_branch):

--- a/release.py
+++ b/release.py
@@ -139,7 +139,7 @@ def create_pullrequest(args, repo):
     if args.user is None or args.token is None:
         msg_error("Missing credentials for GitHub.")
 
-    msg_info(f"Creating a pull request on github for user {args.user}")
+    msg_info(f"Creating a pull request on GitHub for user {args.user}")
     url = f'https://api.github.com/repos/osbuild/{repo}/pulls'
     payload = {'head': f'{args.user}:release-{args.version}',
                'base': 'main',
@@ -203,10 +203,10 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", help=f"Set the version for the release (Default: {version})", default=version)
     parser.add_argument(
-        "--remote", help=f"Set the git remote on github to push the release changes to (Default: {remote})",
+        "--remote", help=f"Set the git remote on GitHub to push the release changes to (Default: {remote})",
         default=remote)
-    parser.add_argument("--user", help=f"Set the username on github (Default: {username})", default=username)
-    parser.add_argument("--token", help="Set the github token used to authenticate")
+    parser.add_argument("--user", help=f"Set the username on GitHub (Default: {username})", default=username)
+    parser.add_argument("--token", help="Set the GitHub token used to authenticate")
     parser.add_argument(
         "--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor}",
         default=editor)

--- a/release.py
+++ b/release.py
@@ -139,7 +139,7 @@ def create_pullrequest(args, repo):
     if args.user is None or args.token is None:
         msg_error("Missing credentials for GitHub.")
 
-    msg_info(f"Creating a pull request on GitHub for user {args.user}")
+    step(f"Create a pull request on GitHub for user {args.user}", None)
     url = f'https://api.github.com/repos/osbuild/{repo}/pulls'
     payload = {'head': f'{args.user}:release-{args.version}',
                'base': 'main',

--- a/release.py
+++ b/release.py
@@ -188,6 +188,18 @@ def release_playbook(args, repo, current_branch):
          ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'])
     create_pullrequest(args, repo)
 
+    step("Has the upstream pull request been merged?", None)
+
+    step("Switch back to the main branch from upstream and update it",
+         ['git','checkout','main','&&','git','pull'])
+
+    step(f"Tag the release {args.version}",
+         ['git', 'tag', '-s', '-m', f'{repo} {args.version}', f'v{args.version}', 'HEAD'])
+
+    step("Push the release upstream", ['git', 'push', f'v{args.version}'])
+
+    # TODO: Create a release on github
+
 
 def main():
     # Do some initial sanity checking of the repository and its state

--- a/release.py
+++ b/release.py
@@ -220,14 +220,14 @@ def main():
     editor = run_command(['git', 'config', '--default', '"${EDITOR:-gedit}"', '--global', 'core.editor'])
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--version", help=f"Set the version for the release (Default: {version})", default=version)
+    parser.add_argument("-v", "--version", help=f"Set the version for the release (Default: {version})", default=version)
     parser.add_argument(
-        "--remote", help=f"Set the git remote on GitHub to push the release changes to (Default: {remote})",
+        "-r", "--remote", help=f"Set the git remote on GitHub to push the release changes to (Default: {remote})",
         default=remote)
-    parser.add_argument("--user", help=f"Set the username on GitHub (Default: {username})", default=username)
-    parser.add_argument("--token", help="Set the GitHub token used to authenticate")
+    parser.add_argument("-u", "--user", help=f"Set the username on GitHub (Default: {username})", default=username)
+    parser.add_argument("-t", "--token", help="Set the GitHub token used to authenticate")
     parser.add_argument(
-        "--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor})",
+        "-e", "--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor})",
         default=editor)
     args = parser.parse_args()
 

--- a/release.py
+++ b/release.py
@@ -185,10 +185,11 @@ def release_playbook(args, repo, current_branch):
              ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py',
               '-s', f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
     elif repo == "osbuild-composer":
-        step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
-             ['git', 'add', 'docs/news', '&&', 'git', 'commit', f'{repo}.spec', 'NEWS.md',
-              'docs/news/unreleased', f'docs/news/{args.version}', '-s',
-              f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
+        step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)", None)
+        run_command(['git', 'add', 'docs/news'])
+        run_command(['git', 'commit', f'{repo}.spec', 'NEWS.md',
+                     'docs/news/unreleased', f'docs/news/{args.version}', '-s',
+                     f'-m {args.version}', f'-m "Release osbuild-composer {args.version}"'])
 
     step(f"Push all release changes to the remote '{args.remote}'",
          ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'])

--- a/release.py
+++ b/release.py
@@ -165,7 +165,7 @@ def release_playbook(args, repo, current_branch):
     elif repo == "osbuild-composer":
         update_news_composer(args)
 
-    step(f"Make the notes in NEWS.md release ready using {args.editor}", [{args.editor}, 'NEWS.md'])
+    step(f"Make the notes in NEWS.md release ready using {args.editor}", [f'{args.editor}', 'NEWS.md'])
 
     step(f"Bump the version where necessary ({repo}.spec, potentially setup.py)", None)
     bump_version(args.version, f"{repo}.spec")
@@ -222,7 +222,7 @@ def main():
     parser.add_argument("--user", help=f"Set the username on GitHub (Default: {username})", default=username)
     parser.add_argument("--token", help="Set the GitHub token used to authenticate")
     parser.add_argument(
-        "--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor}",
+        "--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor})",
         default=editor)
     args = parser.parse_args()
 

--- a/release.py
+++ b/release.py
@@ -7,7 +7,8 @@
 import argparse
 import subprocess, sys
 import os
-
+import getpass
+from re import search
 
 # Check if we are in a git repo, on the right branch and up-to-date
 def sanity_checks():
@@ -20,8 +21,6 @@ def sanity_checks():
     if current_branch != "main":
         print(f"Error: You are not on the 'main' branch but on branch '{current_branch}'.")
         sys.exit(1)
-    else:
-        print(f"Updating '{current_branch}' to avoid conflicts...")
 
     is_clean = run_command(['git', 'status', '--untracked-files=no', '--porcelain'])
     if is_clean != "":
@@ -29,8 +28,6 @@ def sanity_checks():
         print(f"The working directory is not clean.\n"
                "You have the following unstaged or uncommitted changes:\n"
                "{status}")
-    else:
-        run_command(['git', 'pull'])
 
 # Run a shellcommand and return stdout
 def run_command(argv):
@@ -55,7 +52,7 @@ def autoincrement_version():
 
 # Guess the git remote to push the release changes to
 def guess_remote(repo):
-    origin = f"github.com/osbuild/{repo}.git"
+    origin = f"github.com[/:]osbuild/{repo}.git"
     remotes = run_command(['git','remote']).split("\n")
     if len(remotes) > 2:
         print(f"You have more than two 'git remotes' specified, so guessing the correct one will most likely fail.\n"
@@ -64,47 +61,45 @@ def guess_remote(repo):
 
     for remote in remotes:
         remote_url = run_command(['git','remote','get-url',f'{remote}'])
-        if remote_url.__contains__(origin) == False:
+        if search(origin, remote_url) is not None:
             return remote
 
 # Execute all steps of the release playbook
-def release_playbook(version, remote, repo):
-    step(f"Check out a new branch for the release {version}", ['git', 'checkout', '-b', f'release-{version}'])
+def release_playbook(args, repo):
+    step(f"Check out a new branch for the release {args.version}", ['git', 'checkout', '-b', f'release-{args.version}'])
     step("Generate template for new release", ['make', 'release'])
-    step(f"Bump the version to {version}", ['make', 'bump-version'])
-    step(f"Please make sure the version was bumped correctly to {version}", ['git', 'diff'])
+    step(f"Bump the version to {args.version}", ['make', 'bump-version'])
+    step(f"Please make sure the version was bumped correctly to {args.version}", ['git', 'diff'])
     # TODO: Call the pr_summaries.py script for osbuild or assemble the news from docs/news/unreleased for composer
     step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
-          ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py', '-s', f'-m {version}', f'-m "Release osbuild {version}"'])
-    step(f"Push all release changes to the remote '{remote}'",
-          ['git', 'push', '--set-upstream', f'{remote}', f'release-{version}'])
+          ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py', '-s', f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
+    step(f"Push all release changes to the remote '{args.remote}'",
+          ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'])
     # TODO: Create a PR on GitHub automatically (since we know all the necessary infos) and paste a link to it in stdout
     print("Please use github to submit a pull-request against the main repository!")
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--version", help="Set the `version` for the release")
-    parser.add_argument("--remote", help="Set the `remote` on github to push the release changes to")
-    args = parser.parse_args()
-
     # Do some initial sanity checking of the repository and its state
     sanity_checks()
 
-    # Determine the version for the release
-    if (args.version is None):
-        version = autoincrement_version()
-    else:
-        version = args.version
-    
-    # Determine the remote to push the release to
+    # Get some basic fallback/default values
     repo = os.path.basename(os.getcwd())
-    if (args.remote is None):
-        remote = guess_remote(repo)
-    else:
-        remote = args.remote
+    version = autoincrement_version()
+    remote = guess_remote(repo)
+    username = getpass.getuser()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", help=f"Set the version for the release (Default: {version})", default=version)
+    parser.add_argument("--remote", help=f"Set the git remote on github to push the release changes to (Default: {remote})", default=remote)
+    parser.add_argument("--user", help=f"Set the username on github (Default: {username})", default=username)
+    parser.add_argument("--token", help="Set the github token used to authenticate")
+    args = parser.parse_args()
+
+    print(f"Updating branch 'main' to avoid conflicts...")
+    run_command(['git', 'pull'])
 
     # Run the release playbook
-    release_playbook(version, remote, repo)
+    release_playbook(args, repo)
 
 
 if __name__ == "__main__":

--- a/release.py
+++ b/release.py
@@ -16,7 +16,7 @@ import requests
 class fg:
     BOLD = '\033[1m'  # bold
     OK = '\033[32m'  # green
-    WARNING = '\033[33m'  # yellow
+    INFO = '\033[33m'  # yellow
     ERROR = '\033[31m'  # red
     RESET = '\033[0m'  # reset
 
@@ -27,7 +27,7 @@ def msg_error(body):
 
 
 def msg_info(body):
-    print(f"{fg.WARNING}{fg.BOLD}Info:{fg.RESET} {body}")
+    print(f"{fg.INFO}{fg.BOLD}Info:{fg.RESET} {body}")
 
 
 def msg_ok(body):

--- a/release.py
+++ b/release.py
@@ -43,6 +43,8 @@ def sanity_checks():
     current_branch = run_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
     if "release" in current_branch:
         msg_info(f"You are already on a release branch: {current_branch}")
+    elif "rhel-8" in current_branch:
+        msg_info(f"You are going for a point release against: {current_branch}")
     elif current_branch != "main":
         msg_error(f"You are not on the 'main' branch but on branch '{current_branch}'.")
 
@@ -83,7 +85,10 @@ def step(action, args):
 def autoincrement_version():
     """Bump the version of the latest git tag by 1"""
     latest_tag = run_command(['git', 'describe', '--abbrev=0'])
-    version = int(latest_tag.replace("v", "")) + 1
+    if "." in latest_tag:
+        version = latest_tag.replace("v", "").split(".")[0] + "." + str(int(latest_tag[-1]) + 1)
+    else:
+        version = int(latest_tag.replace("v", "")) + 1
     return version
 
 

--- a/release.py
+++ b/release.py
@@ -34,12 +34,14 @@ def run_command(argv):
     result = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8').stdout
     return result.strip()
 
-# Ask the user for confirmation on whether to continue
+# Ask the user for confirmation on whether to accept (y) or skip (s) the step or cancel (N) the playbook
 def step(action, args):
-    # TODO: Consider adding a third state (skip?) so the playbook can be easily restarted
-    feedback = input(f"{action} [y/N] ")
+    feedback = input(f"{action} [y/s/N] ")
     if feedback == "y":
         run_command(args)
+    elif feedback == "s":
+        print("Step skipped.")
+        return
     else:
         print("Release playbook canceled.")
         sys.exit(0)

--- a/release.py
+++ b/release.py
@@ -107,10 +107,10 @@ def update_news_osbuild(args):
     """Update the NEWS file for osbuild"""
     # TODO: Need to decide how to handle the pr_summaries.py file (make it available as .egg?)
     # so it can be properly invoked
+    # TODO: Check the return code of pr_summaries.py to see if things actually worked as planned
     step(f"Update NEWS.md with pull request summaries for milestone {args.version}", [
          '../maintainer-tools/pr_summaries.py', '--version', f'{args.version}', '--token', f'{args.token}'])
-    # TODO: Check the return code of pr_summaries.py to see if things actually worked as planned
-    step(f"Make the notes in NEWS.md release ready", [f'{args.editor}', 'NEWS.md'])
+
 
 def update_news_composer(args):
     """Update the NEWS file for osbuild-composer"""
@@ -118,7 +118,6 @@ def update_news_composer(args):
          ['mkdir', f'docs/news/{args.version}', '&&', 'mv', 'docs/news/unreleased/*', f'docs/news/{args.version}'])
     msg_info(f"Content of docs/news/{args.version}:\n{run_command(['ls',f'docs/news/{args.version}'])}")
     step("Generate template for new release", ['make', 'release'])
-    step("Edit the NEWS.md file", [f'{args.editor}', 'NEWS.md'])
 
 
 def bump_version(version, filename):
@@ -164,6 +163,8 @@ def release_playbook(args, repo, current_branch):
         update_news_osbuild(args)
     elif repo == "osbuild-composer":
         update_news_composer(args)
+
+    step(f"Make the notes in NEWS.md release ready using {args.editor}", [f'{args.editor}', 'NEWS.md'])
 
     step(f"Bump the version where necessary ({repo}.spec, potentially setup.py)", None)
     bump_version(args.version, f"{repo}.spec")

--- a/release.py
+++ b/release.py
@@ -56,10 +56,11 @@ def run_command(argv):
 
 # Ask the user for confirmation on whether to accept (y) or skip (s) the step or cancel (N) the playbook
 def step(action, args):
-    feedback = input(f"{action} [y/s/N] ")
+    feedback = input(f"{fg.BOLD}Step: {fg.RESET}{action} [y/s/N] ")
     if feedback == "y":
-        out = run_command(args)
-        msg_ok (out)
+        if args is not None:
+            out = run_command(args)
+            msg_ok (f"\n{out}")
     elif feedback == "s":
         msg_info("Step skipped.")
         return

--- a/release.py
+++ b/release.py
@@ -63,7 +63,7 @@ def guess_remote(repo):
 
     for remote in remotes:
         remote_url = run_command(['git','remote','get-url',f'{remote}'])
-        if search(origin, remote_url) is not None:
+        if search(origin, remote_url) is None:
             return remote
 
 # Execute all steps of the release playbook

--- a/release.py
+++ b/release.py
@@ -61,7 +61,6 @@ def run_command(argv):
         argv,
         capture_output=True,
         text=True,
-        check=True,
         encoding='utf-8').stdout
     return result.strip()
 
@@ -106,16 +105,12 @@ def guess_remote(repo):
 
 def update_news_osbuild(args):
     """Update the NEWS file for osbuild"""
-    # FIXME: Need to decide how to handle the pr_summaries.py file (make it available as .egg?)
+    # TODO: Need to decide how to handle the pr_summaries.py file (make it available as .egg?)
     # so it can be properly invoked
-    step(f"Collect all PRs for milestone {args.version}", [
+    step(f"Update NEWS.md with pull request summaries for milestone {args.version}", [
          '../maintainer-tools/pr_summaries.py', '--version', f'{args.version}', '--token', f'{args.token}'])
-    if os.path.exists(f'NEWS-{args.version}.md'):
-        msg_ok(f"NEWS file generated: {run_command(['ls','-l',f'NEWS-{args.version}.md'])}")
-        step(f"Edit the NEWS-{args.version}.md file", [f'{args.editor}', f'NEWS-{args.version}.md'])
-    else:
-        msg_info("Something went wrong collecting the pull requests (or you skipped the step).")
-
+    # TODO: Check the return code of pr_summaries.py to see if things actually worked as planned
+    step(f"Make the notes in NEWS.md release ready", [f'{args.editor}', 'NEWS.md'])
 
 def update_news_composer(args):
     """Update the NEWS file for osbuild-composer"""

--- a/release.py
+++ b/release.py
@@ -41,7 +41,7 @@ def sanity_checks():
         msg_error("This is not a git repository.")
 
     current_branch = run_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
-    if current_branch.__contains__("release"):
+    if "release" in current_branch:
         msg_info(f"You are already on a release branch: {current_branch}")
     elif current_branch != "main":
         msg_error(f"You are not on the 'main' branch but on branch '{current_branch}'.")

--- a/release.py
+++ b/release.py
@@ -36,7 +36,9 @@ def sanity_checks():
         msg_error("This is not a git repository.")
 
     current_branch = run_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
-    if current_branch != "main":
+    if current_branch.__contains__("release"):
+        msg_info(f"You are already on a release branch: {current_branch}")
+    elif current_branch != "main":
         msg_error(f"You are not on the 'main' branch but on branch '{current_branch}'.")
 
     is_clean = run_command(['git', 'status', '--untracked-files=no', '--porcelain'])
@@ -45,6 +47,7 @@ def sanity_checks():
         msg_info("The working directory is not clean.\n"
                  "You have the following unstaged or uncommitted changes:\n"
                  f"{status}")
+    return current_branch
 
 # Run a shellcommand and return stdout
 def run_command(argv):
@@ -117,7 +120,7 @@ def release_playbook(args, repo):
 
 def main():
     # Do some initial sanity checking of the repository and its state
-    sanity_checks()
+    current_branch = sanity_checks()
 
     # Get some basic fallback/default values
     repo = os.path.basename(os.getcwd())
@@ -132,8 +135,7 @@ def main():
     parser.add_argument("--token", help="Set the github token used to authenticate")
     args = parser.parse_args()
 
-    msg_info(f"Updating branch 'main' to avoid conflicts...")
-    run_command(['git', 'pull'])
+    msg_info(f"Updating branch '{current_branch}' to avoid conflicts...\n{run_command(['git', 'pull'])}")
 
     # Run the release playbook
     release_playbook(args, repo)

--- a/release.py
+++ b/release.py
@@ -5,34 +5,39 @@
 #
 
 import argparse
-import subprocess, sys
+import subprocess
+import sys
 import os
 import getpass
 from re import search
 import requests
 
-# FIXME: Somehow these colors don't do what they should yet...
+
 class fg:
-    BOLD = '\033[1m' # bold
-    OK = '\033[32m' # green
-    WARNING = '\033[33m' # yellow
-    ERROR = '\033[31m' # red
-    RESET = '\033[0m' # reset
+    BOLD = '\033[1m'  # bold
+    OK = '\033[32m'  # green
+    WARNING = '\033[33m'  # yellow
+    ERROR = '\033[31m'  # red
+    RESET = '\033[0m'  # reset
+
 
 def msg_error(body):
     print(f"{fg.ERROR}{fg.BOLD}Error:{fg.RESET} {body}")
     sys.exit(1)
 
+
 def msg_info(body):
     print(f"{fg.WARNING}{fg.BOLD}Info:{fg.RESET} {body}")
+
 
 def msg_ok(body):
     print(f"{fg.OK}{fg.BOLD}OK:{fg.RESET} {body}")
 
-# Check if we are in a git repo, on the right branch and up-to-date
+
 def sanity_checks():
+    """Check if we are in a git repo, on the right branch and up-to-date"""
     is_git = run_command(['git', 'rev-parse', '--is-inside-work-tree'])
-    if  is_git != "true":
+    if is_git != "true":
         msg_error("This is not a git repository.")
 
     current_branch = run_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
@@ -49,18 +54,25 @@ def sanity_checks():
                  f"{status}")
     return current_branch
 
-# Run a shellcommand and return stdout
+
 def run_command(argv):
-    result = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8').stdout
+    """Run a shellcommand and return stdout"""
+    result = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding='utf-8').stdout
     return result.strip()
 
-# Ask the user for confirmation on whether to accept (y) or skip (s) the step or cancel (N) the playbook
+
 def step(action, args):
+    """Ask the user for confirmation on whether to accept (y) or skip (s) the step or cancel (N) the playbook"""
     feedback = input(f"{fg.BOLD}Step: {fg.RESET}{action} [y/s/N] ")
     if feedback == "y":
         if args is not None:
             out = run_command(args)
-            msg_ok (f"\n{out}")
+            msg_ok(f"\n{out}")
     elif feedback == "s":
         msg_info("Step skipped.")
         return
@@ -68,80 +80,91 @@ def step(action, args):
         msg_info("Release playbook canceled.")
         sys.exit(0)
 
-# Bump the version of the latest git tag by 1
+
 def autoincrement_version():
+    """Bump the version of the latest git tag by 1"""
     latest_tag = run_command(['git', 'describe', '--abbrev=0'])
-    version = int(latest_tag.replace("v","")) + 1
+    version = int(latest_tag.replace("v", "")) + 1
     return version
 
-# Guess the git remote to push the release changes to
+
 def guess_remote(repo):
+    """Guess the git remote to push the release changes to"""
     origin = f"github.com[/:]osbuild/{repo}.git"
-    remotes = run_command(['git','remote']).split("\n")
+    remotes = run_command(['git', 'remote']).split("\n")
     if len(remotes) > 2:
         msg_info("You have more than two 'git remotes' specified, so guessing the correct one will most likely fail.\n"
                  "Please use the --remote argument to set the correct one.\n"
                  f"{remotes}")
 
     for remote in remotes:
-        remote_url = run_command(['git','remote','get-url',f'{remote}'])
+        remote_url = run_command(['git', 'remote', 'get-url', f'{remote}'])
         if search(origin, remote_url) is None:
             return remote
+    return None
 
-# Update the NEWS file for osbuild
-# FIXME: Need to decide how to handle the pr_summaries.py file (make it available as .egg?) so it can be properly invoked
+
 def update_news_osbuild(args):
-    step(f"Collect all PRs for milestone {args.version}", ['../maintainer-tools/pr_summaries.py','--version',f'{args.version}','--token',f'{args.token}'])
+    """Update the NEWS file for osbuild"""
+    # FIXME: Need to decide how to handle the pr_summaries.py file (make it available as .egg?)
+    # so it can be properly invoked
+    step(f"Collect all PRs for milestone {args.version}", [
+         '../maintainer-tools/pr_summaries.py', '--version', f'{args.version}', '--token', f'{args.token}'])
     if os.path.exists(f'NEWS-{args.version}.md'):
         msg_ok(f"NEWS file generated: {run_command(['ls','-l',f'NEWS-{args.version}.md'])}")
-        step(f"Edit the NEWS-{args.version}.md file", [f'{args.editor}',f'NEWS-{args.version}.md'])
+        step(f"Edit the NEWS-{args.version}.md file", [f'{args.editor}', f'NEWS-{args.version}.md'])
     else:
         msg_info("Something went wrong collecting the pull requests (or you skipped the step).")
 
-# Update the NEWS file for osbuild-composer
-def update_news_composer():
+
+def update_news_composer(args):
+    """Update the NEWS file for osbuild-composer"""
     step("Create a docs directory for this release and move all news files to it",
-         ['mkdir',f'docs/news/{args.version}','&&','mv','docs/news/unreleased/*',f'docs/news/{args.version}'])
+         ['mkdir', f'docs/news/{args.version}', '&&', 'mv', 'docs/news/unreleased/*', f'docs/news/{args.version}'])
     msg_info(f"Content of docs/news/{args.version}:\n{run_command(['ls',f'docs/news/{args.version}'])}")
     step("Generate template for new release", ['make', 'release'])
-    step("Edit the NEWS.md file", [f'{args.editor}','NEWS.md'])
+    step("Edit the NEWS.md file", [f'{args.editor}', 'NEWS.md'])
 
-# Bump the version in the spec file
+
 def bump_version(version, filename):
+    """Bump the version in a file"""
     latest_tag = run_command(['git', 'describe', '--abbrev=0'])
     with open(filename, 'r') as file:
         content = file.read()
 
     # Maybe use re.sub in case the version appears a second time in the spec file
-    content = content.replace(latest_tag.replace("v",""), str(version))
+    content = content.replace(latest_tag.replace("v", ""), str(version))
 
     with open(filename, 'w') as file:
         file.write(content)
 
-# Create a pull request on GitHub from the fork to the main repository
+
 def create_pullrequest(args, repo):
+    """Create a pull request on GitHub from the fork to the main repository"""
     if args.user is None or args.token is None:
         msg_error("Missing credentials for GitHub.")
 
     msg_info(f"Creating a pull request on github for user {args.user}")
     url = f'https://api.github.com/repos/osbuild/{repo}/pulls'
-    payload = {'head':f'{args.user}:release-{args.version}',
-               'base':'main',
-               'title':f'Prepare release {args.version}',
-               'body':'Tasks:\n- Bump version\n-Update news',
-              }
+    payload = {'head': f'{args.user}:release-{args.version}',
+               'base': 'main',
+               'title': f'Prepare release {args.version}',
+               'body': 'Tasks:\n- Bump version\n-Update news',
+               }
 
-    r = requests.post(url, json = payload, auth=(args.user,args.token))
+    r = requests.post(url, json=payload, auth=(args.user, args.token))
     # FIXME: Check the return code (201 for success) properly
     try:
         msg_ok(f"Pull request successfully created: {r.json()['url']}")
     except:
         msg_error(f"Failed to create pull request. {r.json()}")
 
-# Execute all steps of the release playbook
+
 def release_playbook(args, repo, current_branch):
-    if current_branch.__contains__("release") == False:
-        step(f"Check out a new branch for the release {args.version}", ['git', 'checkout', '-b', f'release-{args.version}'])
+    """Execute all steps of the release playbook"""
+    if "release" not in current_branch:
+        step(f"Check out a new branch for the release {args.version}", [
+             'git', 'checkout', '-b', f'release-{args.version}'])
 
     if repo == "osbuild":
         update_news_osbuild(args)
@@ -151,21 +174,25 @@ def release_playbook(args, repo, current_branch):
     step(f"Bump the version in the {repo}.spec", None)
     bump_version(args.version, f"{repo}.spec")
     if repo == "osbuild":
-        bump_version(args.version,"setup.py")
+        bump_version(args.version, "setup.py")
 
     print(f"{run_command(['git', 'diff'])}")
     step(f"Please make sure the version was bumped correctly to {args.version}", None)
 
     if repo == "osbuild":
         step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
-            ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py', '-s', f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
+             ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py',
+              '-s', f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
     elif repo == "osbuild-composer":
         step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
-            ['git','add','docs/news','&&','git', 'commit', f'{repo}.spec', 'NEWS.md', 'docs/news/unreleased',f'docs/news/{args.version}', '-s', f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
+             ['git', 'add', 'docs/news', '&&', 'git', 'commit', f'{repo}.spec', 'NEWS.md',
+              'docs/news/unreleased', f'docs/news/{args.version}', '-s',
+              f'-m {args.version}', f'-m "Release osbuild {args.version}"'])
 
     step(f"Push all release changes to the remote '{args.remote}'",
-          ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'])
+         ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'])
     create_pullrequest(args, repo)
+
 
 def main():
     # Do some initial sanity checking of the repository and its state
@@ -181,10 +208,14 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", help=f"Set the version for the release (Default: {version})", default=version)
-    parser.add_argument("--remote", help=f"Set the git remote on github to push the release changes to (Default: {remote})", default=remote)
+    parser.add_argument(
+        "--remote", help=f"Set the git remote on github to push the release changes to (Default: {remote})",
+        default=remote)
     parser.add_argument("--user", help=f"Set the username on github (Default: {username})", default=username)
     parser.add_argument("--token", help="Set the github token used to authenticate")
-    parser.add_argument("--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor}", default=editor)
+    parser.add_argument(
+        "--editor", help=f"Set which editor shall be used for editing text (e.g. NEWS) files (Default: {editor}",
+        default=editor)
     args = parser.parse_args()
 
     msg_info(f"Updating branch '{current_branch}' to avoid conflicts...\n{run_command(['git', 'pull'])}")

--- a/release.py
+++ b/release.py
@@ -139,7 +139,7 @@ def bump_version(version, filename):
         file.write(content)
 
 
-def create_pullrequest(args, repo):
+def create_pullrequest(args, repo, current_branch):
     """Create a pull request on GitHub from the fork to the main repository"""
     if args.user is None or args.token is None:
         msg_error("Missing credentials for GitHub.")
@@ -147,7 +147,7 @@ def create_pullrequest(args, repo):
     step(f"Create a pull request on GitHub for user {args.user}", None)
     url = f'https://api.github.com/repos/osbuild/{repo}/pulls'
     payload = {'head': f'{args.user}:release-{args.version}',
-               'base': 'main',
+               'base': current_branch,
                'title': f'Prepare release {args.version}',
                'body': 'Tasks:\n- Bump version\n-Update news',
                }
@@ -192,7 +192,7 @@ def release_playbook(args, repo, current_branch):
 
     step(f"Push all release changes to the remote '{args.remote}'",
          ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'])
-    create_pullrequest(args, repo)
+    create_pullrequest(args, repo, current_branch)
 
     step("Has the upstream pull request been merged?", None)
 


### PR DESCRIPTION
Fixes #1

There are still some TODOs in this script:

- [x] Automatically create a GitHub PR via the API
- [x] Integrate the osbuild/osbuild-composer specific NEWS routines
- [x] Consider to add a "skip step" option so the playbook can be restarted at any stage