### PR TITLE
release-helper: Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# release.py
+ghapi
+requests
+mistune
+pyyaml


### PR DESCRIPTION
To allow for a simple `pip install -r requirements.txt` before running `release.py`