### PR TITLE
release.py: skip the editing NEWS.md step if no editor is defined

### DIFF
--- a/release.py
+++ b/release.py
@@ -380,9 +380,12 @@ def release_playbook(args, repo, api):
     if res != "skipped":
         update_news(args, repo, api)
 
-    res = step(f"Make the notes in NEWS.md release ready using {args.editor}", None, None)
-    if res != "skipped":
-        subprocess.call([f'{args.editor}', 'NEWS.md'])
+    if args.editor is not None:
+        res = step(f"Make the notes in NEWS.md release ready using {args.editor}", None, None)
+        if res != "skipped":
+            subprocess.call([f'{args.editor}', 'NEWS.md'])
+    else:
+        msg_info("Both $EDITOR and --editor are unset, skipping the editing NEWS.md step")
 
     res = step(f"Bump the version where necessary ({repo}.spec, potentially setup.py)", None, None)
     if res != "skipped":


### PR DESCRIPTION
Otherwise, the script dies with the following exception:

Step: Make the notes in NEWS.md release ready using None [y/s/N] y
Traceback (most recent call last):
  File "/home/obudai/work/maintainer-tools/release.py", line 493, in <module>
    main()
  File "/home/obudai/work/maintainer-tools/release.py", line 489, in main
    release_playbook(args, repo, api)
  File "/home/obudai/work/maintainer-tools/release.py", line 385, in release_playbook
    subprocess.call([f'{args.editor}', 'NEWS.md'])
  File "/usr/lib64/python3.9/subprocess.py", line 349, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'None'