### PR TITLE
release-helper: Skip CI for release PRs

### DIFF
--- a/release.py
+++ b/release.py
@@ -396,7 +396,8 @@ def release_playbook(args, repo, api):
     if repo == "osbuild":
         step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
              ['git', 'commit', f'{repo}.spec', 'NEWS.md', 'setup.py',
-              '-s', '-m', f'{args.version}', '-m', f'Release osbuild {args.version}'], None)
+              '-s', '-m', f'{args.version}', '-m', f'Release osbuild {args.version}','-m','[skip ci]'],
+             None)
     elif repo == "osbuild-composer":
         res = step(f"Add and commit the release-relevant changes ({repo}.spec NEWS.md setup.py)",
                    None, None)
@@ -404,7 +405,8 @@ def release_playbook(args, repo, api):
             run_command(['git', 'add', 'docs/news'])
             run_command(['git', 'commit', f'{repo}.spec', 'NEWS.md',
                         'docs/news/unreleased', f'docs/news/{args.version}', '-s',
-                        '-m', f'{args.version}', '-m', f'Release osbuild-composer {args.version}'])
+                        '-m', f'{args.version}', '-m', f'Release osbuild-composer {args.version}',
+                        '-m','[skip ci]'])
 
     step(f"Push all release changes to the remote '{args.remote}'",
          ['git', 'push', '--set-upstream', f'{args.remote}', f'release-{args.version}'], None)


### PR DESCRIPTION
Reference:
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/