### PR TITLE
release-helper: Bring back pushing the tag

### DIFF
--- a/release.py
+++ b/release.py
@@ -224,6 +224,7 @@ def step_create_release_tag(args, repo, api):
     if res != "skipped":
         create_release_tag(args, repo, api)
 
+    step("Push the release tag upstream", ['git', 'push', 'origin', f'v{args.version}'], None)
 
 def main():
     """Main function"""


### PR DESCRIPTION
Dropping this line was an oversight in eb7eac98822293ef6f803740f3d78d4a7df18956