### PR TITLE
release: don't leave empty line between changelog items

### DIFF
--- a/release.py
+++ b/release.py
@@ -173,7 +173,7 @@ def get_pullrequest_infos(args, repo, api, hashes):
 
     summaries = list(dict.fromkeys(summaries))
     msg_ok(f"Collected summaries from {len(summaries)} pull requests ({i} commits).")
-    return "\n\n".join(summaries)
+    return "\n".join(summaries)
 
 
 def get_contributors(args):


### PR DESCRIPTION
Lists without blank lines between items look nicer.

See for example osbuild release [37](https://github.com/osbuild/osbuild/releases/tag/v37) vs [43](https://github.com/osbuild/osbuild/releases/tag/v43).