### PR TITLE
Make the GitHub token mandatory

### DIFF
--- a/release.py
+++ b/release.py
@@ -255,6 +255,9 @@ def main():
 
     args.latest_tag = latest_tag
 
+    if args.token is None:
+        msg_error("Please supply a valid GitHub token.")
+
     msg_info(f"Updating branch '{args.base}' to avoid conflicts...\n{run_command(['git', 'pull'])}")
 
     api = GhApi(repo=repo, owner='osbuild', token=args.token)


### PR DESCRIPTION
Without supplying a token we will run into issues with API call rate
limiting. Alternatively we could of course wait a long time between each
call, but then again it is really easy to create and supply a token.