### PR TITLE
release: check if the origin is valid

### DIFF
--- a/release.py
+++ b/release.py
@@ -75,7 +75,8 @@ def sanity_checks(repo):
     origin_url = run_command(['git', 'remote', 'get-url', 'origin'])
     if origin_url not in valid_origins:
         msg_error("The 'origin' remote is not properly configured.\n"
-                  "Make sure to have a remote named 'origin' pointed to the upstream repository.")
+                  "Make sure to have a remote named 'origin' pointed to the upstream repository.\n"
+                  f"E.g. by running 'git remote add origin git@github.com:osbuild/{repo}.git'")
 
     return current_branch
 

--- a/release.py
+++ b/release.py
@@ -71,6 +71,12 @@ def sanity_checks(repo):
                   "'gpg --list-secret-keys --keyid-format=long'\n"
                   "Please then set it using 'git config --global user.signingkey FINGERPRINT'")
 
+    valid_origins = [f"https://github.com/osbuild/{repo}.git", f"git@github.com:osbuild/{repo}.git"]
+    origin_url = run_command(['git', 'remote', 'get-url', 'origin'])
+    if origin_url not in valid_origins:
+        msg_error("The 'origin' remote is not properly configured.\n"
+                  "Make sure to have a remote named 'origin' pointed to the upstream repository.")
+
     return current_branch
 
 


### PR DESCRIPTION
If there is no origin remote pointing to the upstream repository the release script will now warn the user. This prevents the tags from being pushed to the wrong remote.